### PR TITLE
improve extraction, add option to get JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.now


### PR DESCRIPTION
Adds an option to provide an `Accept: application/json` header to receive a list of all CSS origins that were scraped and their respective CSS.
Also updates the scraping to the 2.1.0 of bartveneman/extract-css-core.